### PR TITLE
Support for custom event publishing strategy

### DIFF
--- a/doc/getting_started.md
+++ b/doc/getting_started.md
@@ -71,12 +71,22 @@ This will log consumed messages to the `asynchronous_command_bus` and `asynchron
 
 ## Choose event strategy
 
-When handling events you have two strategies to choose from. Either you publish *all* events to the message queue or
-you only publish the events that have a registered subscriber. If your application is the only one that consuming messages
-you should consider using the **predefined** strategy. This will reduce the message overhead on the message queue. 
+When handling events you have two predefined strategies to choose from. Either you publish *all* events to the message
+queue (*always* strategy) or you only publish the events that have a registered asynchronous subscriber
+(*predefined* strategy). If your application is the only one that is consuming messages you should consider using the
+**predefined** strategy. This will reduce the message overhead on the message queue.
 
 ```yaml
 simple_bus_asynchronous:
   events:
     strategy: 'predefined' # default: 'always'
+```
+
+You can also use Your own strategy by defining custom **strategy_service_id**
+
+```yaml
+simple_bus_asynchronous:
+  events:
+    strategy:
+      strategy_service_id: your_strategy_service
 ```

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -43,10 +43,27 @@ class Configuration implements ConfigurationInterface
                 ->arrayNode('events')
                     ->canBeEnabled()
                     ->children()
-                        ->enumNode('strategy')
+                        ->arrayNode('strategy')
+                            ->addDefaultsIfNotSet()
+                            ->beforeNormalization()
+                                ->ifInArray(['always', 'predefined'])
+                                ->then(function ($v) {
+                                    $map = [
+                                        'always'     => 'simple_bus.asynchronous.always_publishes_messages_middleware',
+                                        'predefined' => 'simple_bus.asynchronous.publishes_predefined_messages_middleware',
+                                    ];
+
+                                    return [
+                                        'strategy_service_id' => $map[$v]
+                                    ];
+                                })
+                            ->end()
                             ->info('What strategy to use to publish messages')
-                            ->defaultValue('always')
-                            ->values(['always', 'predefined'])
+                            ->children()
+                                ->scalarNode('strategy_service_id')
+                                ->defaultValue('simple_bus.asynchronous.always_publishes_messages_middleware')
+                                ->end()
+                            ->end()
                         ->end()
                         ->scalarNode('publisher_service_id')
                             ->info('Service id of an instance of Publisher')

--- a/src/DependencyInjection/SimpleBusAsynchronousExtension.php
+++ b/src/DependencyInjection/SimpleBusAsynchronousExtension.php
@@ -96,12 +96,7 @@ class SimpleBusAsynchronousExtension extends ConfigurableExtension
             $loader->load('asynchronous_events_logging.yml');
         }
 
-
-        if ($config['strategy'] === 'always') {
-            $eventMiddleware = 'simple_bus.asynchronous.always_publishes_messages_middleware';
-        } else {
-            $eventMiddleware = 'simple_bus.asynchronous.publishes_predefined_messages_middleware';
-        }
+        $eventMiddleware = $config['strategy']['strategy_service_id'];
 
         // insert before the middleware that actually notifies a message subscriber of the message
         $container->getDefinition($eventMiddleware)->addTag('event_bus_middleware', ['priority' => 0]);

--- a/tests/Unit/DepencencyInjection/SimpleBusAsynchronousExtensionTest.php
+++ b/tests/Unit/DepencencyInjection/SimpleBusAsynchronousExtensionTest.php
@@ -5,7 +5,6 @@ namespace SimpleBus\AsynchronousBundle\Tests\Unit\DependencyInjection;
 
 use Matthias\SymfonyDependencyInjectionTest\PhpUnit\AbstractExtensionTestCase;
 use SimpleBus\AsynchronousBundle\DependencyInjection\SimpleBusAsynchronousExtension;
-use Symfony\Component\DependencyInjection\ContainerBuilder;
 
 class SimpleBusAsynchronousExtensionTest extends AbstractExtensionTestCase
 {
@@ -25,7 +24,7 @@ class SimpleBusAsynchronousExtensionTest extends AbstractExtensionTestCase
     /**
      * @test
      */
-    public function it_uses_strategy_allways_by_default()
+    public function it_uses_strategy_always_by_default()
     {
         $this->container->setParameter('kernel.bundles', ['SimpleBusCommandBusBundle'=>true, 'SimpleBusEventBusBundle'=>true]);
         $this->load();
@@ -43,7 +42,18 @@ class SimpleBusAsynchronousExtensionTest extends AbstractExtensionTestCase
 
         $this->assertContainerBuilderHasServiceDefinitionWithTag('simple_bus.asynchronous.publishes_predefined_messages_middleware', 'event_bus_middleware', ['priority'=>0]);
     }
-    
+
+    /**
+     * @test
+     * @expectedException \Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException
+     * @expectedExceptionMessageRegExp ".*custom_strategy.*"
+     */
+    public function it_uses_custom_strategy_when_configured()
+    {
+        $this->container->setParameter('kernel.bundles', ['SimpleBusCommandBusBundle'=>true, 'SimpleBusEventBusBundle'=>true]);
+        $this->load(['events'=>['strategy'=>['strategy_service_id'=>'custom_strategy']]]);
+    }
+
     /**
      * @test
      * @expectedException \LogicException
@@ -54,7 +64,7 @@ class SimpleBusAsynchronousExtensionTest extends AbstractExtensionTestCase
         $this->container->setParameter('kernel.bundles', ['SimpleBusEventBusBundle'=>true]);
         $this->load(['events'=>['strategy'=>'predefined']]);
     }
-    
+
     /**
      * @test
      * @expectedException \LogicException


### PR DESCRIPTION
There are 2 strategies of handling events: `always` and `predefined`. I've added ability to define custom one (using a backward compatible configuration).

``` yaml
simple_bus_asynchronous:
    events:
        strategy:
            strategy_service_id: custom_strategy_service
```
### TODO
- [x] Add tests
- [x] Add docs
### Related

Related to: SimpleBus/AsynchronousBundle#6
