### PR TITLE
Fix typo > `Asyncronous > Asynchronous`

### DIFF
--- a/src/Bus/AsynchronousCommandBus.php
+++ b/src/Bus/AsynchronousCommandBus.php
@@ -4,7 +4,7 @@ namespace SimpleBus\AsynchronousBundle\Bus;
 
 use SimpleBus\Message\Bus\Middleware\MessageBusSupportingMiddleware;
 
-class AsyncronousCommandBus extends MessageBusSupportingMiddleware
+class AsynchronousCommandBus extends MessageBusSupportingMiddleware
 {
 
 }

--- a/src/Bus/AsynchronousEventBus.php
+++ b/src/Bus/AsynchronousEventBus.php
@@ -4,7 +4,7 @@ namespace SimpleBus\AsynchronousBundle\Bus;
 
 use SimpleBus\Message\Bus\Middleware\MessageBusSupportingMiddleware;
 
-class AsyncronousEventBus extends MessageBusSupportingMiddleware
+class AsynchronousEventBus extends MessageBusSupportingMiddleware
 {
 
 }

--- a/src/Resources/config/asynchronous_commands.yml
+++ b/src/Resources/config/asynchronous_commands.yml
@@ -6,7 +6,7 @@ services:
         alias: simple_bus.asynchronous.command_bus
 
     simple_bus.asynchronous.command_bus:
-        class: SimpleBus\AsynchronousBundle\Bus\AsyncronousCommandBus
+        class: SimpleBus\AsynchronousBundle\Bus\AsynchronousCommandBus
         public: false
         tags:
             - { name: message_bus, type: command, middleware_tag: asynchronous_command_bus_middleware }

--- a/src/Resources/config/asynchronous_events.yml
+++ b/src/Resources/config/asynchronous_events.yml
@@ -3,7 +3,7 @@ services:
         alias: simple_bus.asynchronous.event_bus
 
     simple_bus.asynchronous.event_bus:
-        class: SimpleBus\AsynchronousBundle\Bus\AsyncronousEventBus
+        class: SimpleBus\AsynchronousBundle\Bus\AsynchronousEventBus
         public: false
         tags:
             - { name: message_bus, type: event, middleware_tag: asynchronous_event_bus_middleware }


### PR DESCRIPTION
Just wanted to create a new release, and found this typo 😅  Lets fix this first, and then release :) 

Release notes:
```
* Change type to symfony-bundle for Symfony Flex #14
* Add `AsynchronousCommandBus and AsynchronousEventBus classes to support Symfony Autowiring #15 #18
* AutoRegister all public methods #16
```